### PR TITLE
First integration of PagePopularity algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ in Finland. This repository contains ahmia.fi source code.
 # Compatibility
 
 The newest version of Ahmia is built with Python 3.6, Django 1.11 and Elasticsearch 6.2 (5.6 is also compatible).
-Python 2.7+ should be ok too, but preferably try Python 3 instead.
 You will need to know these technologies to create a working Ahmia installation.
 Ahmia crawls using [OnionBot](https://github.com/ahmia/ahmia-crawler).
 
@@ -64,8 +63,7 @@ at least the postgresql credentials, if you are using the production settings.
 
 ### Migrate db
 ```sh
-$ python3 ahmia/manage.py makemigrations ahmia
-$ python3 ahmia/manage.py makemigrations search
+$ python3 ahmia/manage.py makemigrations
 $ python3 ahmia/manage.py migrate
 ```
 
@@ -87,9 +85,9 @@ $ python3 ahmia/manage.py runserver
 
 ## Crontab
 
-* Rule to remove '/onionsadded' weekly
+* Rule to remove onions added by users weekly
 ```sh
-0 22 * * * python /usr/local/bin/ahmia-site/ahmia/manage.py remove_onions --settings=ahmia.settings.prod
+0 0 */7 * * python /usr/local/bin/ahmia-site/ahmia/manage.py remove_onions --settings=ahmia.settings.prod
 ```
 
 * Rule to update usage statistics hourly (could be once per day as well)
@@ -97,10 +95,13 @@ $ python3 ahmia/manage.py runserver
 59 * * * * python /usr/local/bin/ahmia-site/ahmia/manage.py update_stats --settings=ahmia.settings.prod
 ```
 
-* Rule to clean up the DB on the first day of each month
+* Rule to clean up some DB tables on the first day of each month
 ```sh
 0 0 1 * * python /usr/local/bin/ahmia-site/ahmia/manage.py cleanup_db --settings=ahmia.settings.prod
 ```
+
+* Rule to build PagePopularity Score Index every 10 days
+0 0 */10 * * python /usr/local/bin/ahmia-site/ahmia/manage.py calc_page_pop --settings=ahmia.settings.prod
 
 __NOTE__: If you are using virtualenv replace `python` with the absolute path to your virtualenv's python executable, e.g `/path/to/venv/bin/python`
 
@@ -111,14 +112,17 @@ __NOTE__: If your deployment directory isn't `/usr/local/bin/ahmia-site` replace
 You should use [OnionElasticBot](https://github.com/ahmia/ahmia-crawler/tree/master/onionElasticBot) to populate your index.
 
 ## Why can't my browser load django statics ?
-The django settings.py is configured in a way that it only serve statics if DEBUG is True. Please verify [here](https://github.com/ahmia/ahmia-site/blob/master/ahmia/ahmia/settings.py#L9) if it's the case. You can change this behaviour [here](https://github.com/ahmia/ahmia-site/blob/master/ahmia/ahmia/urls.py#L18).
+The django settings.py is configured in a way that it only serve statics if DEBUG is True.
+Please verify [here](https://github.com/ahmia/ahmia-site/blob/master/ahmia/ahmia/settings/dev.py#L6)
+if it's the case. You can change this behaviour
+[here](https://github.com/ahmia/ahmia-site/blob/master/ahmia/ahmia/urls.py#L71).
 
 ## What should I use to host ahmia in a production environment ?
 
 We suggest to deploy ahmia using Apache2 or Nginx with Gunicorn.
 Config samples are in [config/](https://github.com/ahmia/ahmia-site/tree/master/conf).
 
-* First you need to create a postgres database, and insert the database credentials in
+* Moreover you need to create a postgres database, and insert the database credentials in
 `ahmia/ahmia/settings/.env`.
 
 * Configure and run nginx:

--- a/ahmia/ahmia/admin.py
+++ b/ahmia/ahmia/admin.py
@@ -1,10 +1,28 @@
 from django.contrib import admin
 
-
 from .models import *
 
+
+class PagePopAdmin(admin.ModelAdmin):
+    ordering = ('-score',)
+
+
+class MetricAdmin(admin.ModelAdmin):
+    ordering = ('-occurrences',)
+
+
+class SearchQueryAdmin(MetricAdmin):
+    pass
+
+
+class SearchResultsClickAdmin(MetricAdmin):
+    pass
+
+
 admin.site.register(HiddenWebsite)
-admin.site.register(SearchResultsClick)
-admin.site.register(SearchQuery)
+admin.site.register(PagePopScore, PagePopAdmin)
+admin.site.register(PagePopStats)
+admin.site.register(SearchResultsClick, SearchResultsClickAdmin)
+admin.site.register(SearchQuery, SearchQueryAdmin)
 admin.site.register(TorStats)
 admin.site.register(I2PStats)

--- a/ahmia/ahmia/lib/pagepop.py
+++ b/ahmia/ahmia/lib/pagepop.py
@@ -1,0 +1,222 @@
+import itertools
+import logging
+
+import numpy as np
+from scipy import sparse
+
+from ahmia import utils
+from ahmia.models import PagePopScore, PagePopStats
+from ahmia.validators import is_valid_full_onion_url, is_valid_onion
+
+logger = logging.getLogger('ahmia')
+
+
+class PagePopHandler(object):
+
+    def __init__(self, documents=None, beta=0.85, epsilon=10 ** -6):
+        """
+        Handler for PagePop algorithm. It uses a :dict: `domain_idxs` in
+        order to assign each domain an id, that's the corresponding
+        index to `scores`, list, that hold the pagepop scores.
+        ``self.num_domains`` is used as  a counter while building
+        adjacency matrix and ``domain_idxs`` is also stored as an
+        instance attribute for statistics purposes.
+
+        :param documents: An iterable to fetch documents from. It should be a
+            generator in order to reduce memory used.
+        :param beta: 1-teleportation probability.
+        :param epsilon: stop condition. Minimum allowed amount of change
+            in the PagePops between iterations.
+        """
+        self.documents = documents
+        self.beta = beta
+        self.epsilon = epsilon
+
+        self.domains_idxs = {}
+        self.scores = None
+
+        self.num_domains = 0
+        self.num_links = None
+        self.num_edges = None
+
+    def _get_domain_idx(self, domain):
+        domain_idxs = self.domains_idxs
+
+        if domain not in domain_idxs:
+            domain_idxs[domain] = self.num_domains
+            self.num_domains += 1
+
+        return domain_idxs[domain]
+
+    def _store_page_pop_stats(self):
+        kwargs = self.get_stats()
+
+        _, _ = PagePopStats.objects.update_or_create(
+            day=utils.timezone_today(),
+            defaults=kwargs)
+
+    def get_stats(self):
+        """
+        Return number of domains (nodes), links (total links),
+        edges (unique inter-site links) as a dict
+
+        :rtype: ``dict``
+        """
+        ret = {
+            'num_nodes': self.num_domains,
+            'num_links': self.num_links,
+            'num_edges': self.num_edges
+        }
+
+        return ret
+
+    def build_adjacency_graph(self, documents):
+        """
+        Constructs adjacency graph for outgoing links, saves to self.adj_graph
+
+        :param documents: An iterable that contains the ES documents.
+            Preferably a generator to reduce RAM usage.
+        :return: adjacency matrix
+        :rtype: ``list`` of tuples
+        """
+        documents = documents or self.documents
+        adj_graph = []
+
+        for doc in documents:
+            source = doc['_source']
+
+            if 'domain' in source:
+                origin = source['domain']
+            elif 'source' in source:
+                origin = source['source']
+            else:
+                logger.info('rank_pages: Unable to process: %s' % source)
+                continue
+
+            origin = utils.extract_domain_from_url(origin)
+            if is_valid_onion(origin):
+                origin_idx = self._get_domain_idx(origin)
+
+                links = source.get('links', [])  # domain case
+                if 'target' in source:           # source case
+                    links.append({'link': source['target']})
+                for l in links:
+                    url = l['link']
+                    if is_valid_full_onion_url(url):
+                        destiny = utils.extract_domain_from_url(url)
+                        if destiny != origin:
+                            destiny_idx = self._get_domain_idx(destiny)
+                            adj_graph.append((origin_idx, destiny_idx))
+
+        self.num_links = len(adj_graph)  # total links
+        adj_graph = set(adj_graph)  # count only 1 edge of source->destiny
+        self.num_edges = len(adj_graph)  # unique links
+
+        return adj_graph
+
+    def build_sparse_matrix(self, adj_graph, num_nodes=None):
+        """
+        Builds a sparse matrix needed by compute_page_pop()
+
+        :param adj_graph: A directed adjacency pragh as an iterable structure
+        :param num_nodes: The number of nodes referenced in adj_graph
+        :return: A sparse boolean matrix representing a link map
+        :rtype: ``scipy.sparse.csr.csr_matrix``
+        """
+        num_nodes = num_nodes or self.num_domains
+
+        row = [edge[1] for edge in adj_graph]  # destinies
+        col = [edge[0] for edge in adj_graph]  # origins
+
+        # if number of nodes not supplied count distinctly the nodes
+        num_nodes = num_nodes or len(set(itertools.chain(row, col)))
+        # print("nodes counted: %s" % len(set(itertools.chain(row, col))))
+
+        return sparse.csr_matrix(
+            ([True] * len(adj_graph), (row, col)),
+            shape=(num_nodes, num_nodes))
+
+    def compute_page_pop(self, adj, beta=None, epsilon=None):
+        """
+        Efficient computation of the PagePop values using a sparse adjacency
+        matrix and the iterative power method.
+        based on https://is.gd/weFAC1 (blog.samuelmh.com)
+
+        :param adj: boolean adjacency matrix. If adj_j,i is True,
+            then there is a link from i to j
+        :type adj: scipy.sparse.csr.csr_matrix
+        :param beta: 1-teleportation probability.
+        :param epsilon: stop condition. Minimum allowed amount of
+            change in the PagePops between iterations.
+        :return: PagePop array normalized
+        :rtype: ``numpy.ndarray``
+        """
+        beta = beta or self.beta
+        epsilon = epsilon or self.epsilon
+
+        n, _ = adj.shape
+        # Test adjacency matrix is OK
+        assert (adj.shape == (n, n))
+
+        # Constants Speed-UP
+        deg_out_beta = adj.sum(axis=0).T / beta  # vector
+
+        # Initialize
+        scores = np.ones((n, 1)) / n  # vector
+
+        iterations = 0
+        flag = True
+        while flag:
+            iterations += 1
+            with np.errstate(divide='ignore'):
+                # Ignore division by 0 on scores/deg_out_beta
+                new_scores = adj.dot((scores / deg_out_beta))  # vector
+            # Leaked PagePop
+            new_scores += (1 - new_scores.sum()) / n
+            # Stop condition
+            if np.linalg.norm(scores - new_scores, ord=1) <= epsilon:
+                flag = False
+            scores = new_scores
+
+        self.scores = scores
+        return scores
+
+    def save(self):
+        """
+        Associates each onion with its score, using the parallel
+        structures: self.domain_idxs, self.scores, and stores the
+        results in the DB: PagePop model
+        """
+        # Bulk Delete
+        PagePopScore.objects.all().delete()
+
+        # Associate onion with its score and create PagePop objs
+        objs = []
+        for onion, index in self.domains_idxs.items():
+            kwargs = {
+                'onion': onion,
+                'score': self.scores[index],
+                # 'score_norm': self.norm_scores[index]
+            }
+            new_obj = PagePopScore(**kwargs)
+            objs.append(new_obj)
+
+        # Bulk Save the objects into the DB
+        PagePopScore.objects.bulk_create(objs)
+
+        # save stats
+        self._store_page_pop_stats()
+
+    def build_pagescores(self, documents=None):
+        """
+        Calculate the popularity of each domain and save scores to
+        `self.scores`, and the respecting indices in `self.domain_idxs`.
+
+        :param documents: An iterable that yields all the ES documents.
+            If not provided, the instance (class) attribute is used.
+        """
+        doc_generator = documents or self.documents
+
+        adj_graph = self.build_adjacency_graph(doc_generator)
+        matrix = self.build_sparse_matrix(adj_graph)
+        _ = self.compute_page_pop(matrix)

--- a/ahmia/ahmia/management/commands/calc_page_pop.py
+++ b/ahmia/ahmia/management/commands/calc_page_pop.py
@@ -1,0 +1,33 @@
+from django.core.management import BaseCommand
+from elasticsearch.helpers import scan
+
+from ahmia import utils
+from ahmia.lib.pagepop import PagePopHandler
+
+
+class Command(BaseCommand):
+    help = 'Ranks Pages Based on PagePop algorithm found in ahmia/lib'
+
+    def __init__(self):
+        super(BaseCommand, self).__init__()
+
+        self.es_obj = utils.get_elasticsearch_object()
+        self.es_index = utils.get_elasticsearch_tor_index()
+
+    def _fetch_all_docs(self):
+        """Returns a generator to iterate all records"""
+        doc_gen = scan(
+            self.es_obj,
+            query={"query": {"match_all": {}}},
+            index=self.es_index,
+            scroll='2m',
+        )
+
+        return doc_gen
+
+    def handle(self, *args, **options):
+        doc_gen = self._fetch_all_docs()
+
+        p = PagePopHandler(documents=doc_gen, beta=0.85)
+        p.build_pagescores()
+        p.save()

--- a/ahmia/ahmia/tests/test_lib.py
+++ b/ahmia/ahmia/tests/test_lib.py
@@ -1,0 +1,37 @@
+from django.test import TestCase
+
+from ahmia.lib.pagepop import PagePopHandler
+
+
+class TestPagePop(TestCase):
+    def test_compute_page_pop(self):
+        p = PagePopHandler()
+
+        # Case 1:
+        # Consider 0,1,2,3 are A,B,C,D
+        adj_mat = [
+            (1, 0),  # B -> A
+            (3, 0),  # D -> A
+            (0, 2),  # A -> C
+            (3, 1),  # D -> B
+        ]
+
+        sparse = p.build_sparse_matrix(adj_mat)
+        ranks = p.compute_page_pop(sparse)
+        # print(ranks)
+        assert ranks[2] > ranks[0] > ranks[1] > ranks[3]  # C > A > B > D
+
+        # Case 2:
+        # Consider 0,1,2,3,4 are A,B,C,D,E
+        adj_mat = [
+            (0, 1),  # A -> B
+            (1, 2),  # B -> C
+            (2, 3),  # C -> D
+            (3, 0),  # D -> A
+            (4, 0),  # E -> A
+        ]
+
+        sparse = p.build_sparse_matrix(adj_mat)
+        ranks = p.compute_page_pop(sparse, beta=0.6)
+        # print(ranks)
+        assert ranks[0] > ranks[1] > ranks[2] > ranks[3] > ranks[4]

--- a/ahmia/ahmia/utils.py
+++ b/ahmia/ahmia/utils.py
@@ -1,4 +1,5 @@
-""" Utility fonctions """
+""" Utility fonctions used by all apps """
+
 from django.conf import settings
 from django.utils import timezone
 from elasticsearch import Elasticsearch
@@ -35,3 +36,40 @@ def get_elasticsearch_type():
 def timezone_today():
     """ Timezone aware function that returns the current day"""
     return timezone.now().date()
+
+
+def extract_domain_from_url(url):
+    """
+    Removes protocol, subdomain and url path. It does not
+    perform any validation on input parameter url
+
+    :param url Full onion url as str
+    :return domain name as str
+    """
+    if '.onion' not in url:
+        return None
+
+    no_path_no_tld = url.split('.onion')[0]
+    domain_name = no_path_no_tld.split('.')[-1].split('/')[-1]
+    domain = domain_name + '.onion'
+
+    return domain
+
+
+def normalize_on_max(scalars):
+    """
+    Normalize ``scallars`` to have max value: 1
+
+    :param scalars: Python iterable (not numpy)
+    :return: A normalized version of input
+    """
+    max_i = max(scalars)
+    class_type = type(scalars)
+
+    ret = class_type(i / max_i for i in scalars)
+
+    return ret
+
+
+# todo: these functions are also used by `search` so
+# it might be cleaner to make `utils` a separate app

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -24,3 +24,4 @@ networkx==2.1
 python-decouple==3.1
 wheel>=0.30
 matplotlib==2.2.2
+scipy==1.1.0


### PR DESCRIPTION
* The necessary Models to store the popularity score for each onion,
as well as the statistics of the last calculation (links, domains)
* added a subfolder ahmia/ahmia/lib that contains the PagePop algorithm
implementation. Other helper modules could be stored in this folder in
the future.
* A management command to build popularity index and save it in the DB
* search/views.py updated to sort results based on both IR score
(the one ES calculates) and PP score (provided by the aforementioned
command). Optimizing the formula handling those scores is Black Art and
needs further testing
* Admin page updated to display the PapePop scores
* Update README.md

The current results of the integration don't seem perfect, but we are going to improve further the algorithm

ref: #30