### PR TITLE
Fix for unknown edge case where encode() would raise UnicodeEncodeError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 python:
   - 3.6
 install:
-  - pip install -r requirements/dev.txt
+  - pip install -r requirements/prod.txt
 before_script:
   - cp ahmia/ahmia/settings/example.env ahmia/ahmia/settings/.env
   - python ahmia/manage.py migrate

--- a/ahmia/ahmia/lib/pagepop.py
+++ b/ahmia/ahmia/lib/pagepop.py
@@ -101,7 +101,7 @@ class PagePopHandler(object):
                 if 'target' in source:           # source case
                     links.append({'link': source['target']})
                 for l in links:
-                    url = l['link']
+                    url = l['link'].encode('utf-8', 'ignore').decode()
                     if is_valid_full_onion_url(url):
                         destiny = utils.extract_domain_from_url(url)
                         if destiny != origin:


### PR DESCRIPTION
* Manually encode the url ignoring uknown characters in order to prevent `str()` to fail with UnicodeEncodeError
* Update travis.yml to user production pip packages