### PR TITLE
Implementation of local (online) page popularity

### DIFF
--- a/ahmia/ahmia/management/commands/calc_page_pop.py
+++ b/ahmia/ahmia/management/commands/calc_page_pop.py
@@ -32,8 +32,8 @@ class Command(BaseCommand):
         return doc_gen
 
     def handle(self, *args, **options):
-        doc_gen = self._fetch_all_docs()
+        entries = self._fetch_all_docs()
 
-        p = PagePopHandler(documents=doc_gen, beta=0.85)
+        p = PagePopHandler(entries=entries, beta=0.85)
         p.build_pagescores()
         p.save()

--- a/ahmia/ahmia/tests/test_lib.py
+++ b/ahmia/ahmia/tests/test_lib.py
@@ -16,8 +16,8 @@ class TestPagePop(TestCase):
             (3, 1),  # D -> B
         ]
 
-        sparse = p.build_sparse_matrix(adj_mat)
-        ranks = p.compute_page_pop(sparse)
+        sparse = p._build_sparse_matrix(adj_mat)
+        ranks = p._compute_page_pop(sparse)
         # print(ranks)
         assert ranks[2] > ranks[0] > ranks[1] > ranks[3]  # C > A > B > D
 
@@ -31,7 +31,7 @@ class TestPagePop(TestCase):
             (4, 0),  # E -> A
         ]
 
-        sparse = p.build_sparse_matrix(adj_mat)
-        ranks = p.compute_page_pop(sparse, beta=0.6)
+        sparse = p._build_sparse_matrix(adj_mat)
+        ranks = p._compute_page_pop(sparse, beta=0.6)
         # print(ranks)
         assert ranks[0] > ranks[1] > ranks[2] > ranks[3] > ranks[4]

--- a/ahmia/ahmia/utils.py
+++ b/ahmia/ahmia/utils.py
@@ -76,7 +76,3 @@ def normalize_on_max(scalars):
     ret = class_type(i / max_i for i in ret)
 
     return ret
-
-
-# todo: these functions are also used by `search` so
-# it might be cleaner to make `utils` a separate app


### PR DESCRIPTION
* Calls the common PagePopHandler for the entries returned by the search result only
* Include local pagepop score to sorting criteria
* Make local pagepop and global pagepop coefficients ulr parameters `lp`, `gp`,
in order to be able to test online on the production. That becomes also the pagepop
triggering parameter. Thus by supplying these, the pagepop is enabled.
* Adjust PagePopHandler to filter links for specific domains, used for local pagepop
* Placeholder code `is_legit_link` function, to identify SE-spam links
* Minor refactoring of PagePopHandler for clarity reasons. Some variables have been renamed.
* tests have been adjusted to the aforementioned refactoring
* TODOs included in pagepop.py

ref: #30