### PR TITLE
 Solving #28 issue 

### DIFF
--- a/ahmia/ahmia/settings/base.py
+++ b/ahmia/ahmia/settings/base.py
@@ -144,6 +144,9 @@ MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
 
 # *** LOGGING *** #
 
+# Override exception method for use the same format as in 'error'
+logging.Logger.exception = logging.Logger.error   
+
 # Log everything to the logs directory at the top
 LOGFILE_ROOT = ROOT_PATH('logs')
 if not os.path.exists(LOGFILE_ROOT):

--- a/ahmia/ahmia/settings/base.py
+++ b/ahmia/ahmia/settings/base.py
@@ -4,6 +4,7 @@ from os.path import dirname, join, abspath
 
 from decouple import config, Csv
 
+import logging
 
 # Set the PROJECT_HOME variable.
 # This will be used to prepend to all file/directory paths.


### PR DESCRIPTION
Modifying logger.exception(e) behaviour to fullfill #28 issue. The `logger.exception` method works exactly equal as `logger.error`, with the only difference that `logger.exception` prints the stack trace (as [logging documentation](https://docs.python.org/2/library/logging.html#logging.Logger.exception) says).

For example:

```
(ahmia-site-y9pbFE0o) junquera@aio:~/ahmia-site$ python3 test.py 

[*] Without the override

[22/Oct/2018 23:44:45] ERROR [exception:test.py:37] division by zero
Traceback (most recent call last):
  File "test.py", line 32, in <module>
    a = 2/b
ZeroDivisionError: division by zero

[*] With the override

[22/Oct/2018 23:44:45] ERROR [exception:test.py:42] division by zero
```

![captura de pantalla de 2018-10-22 23-45-37](https://user-images.githubusercontent.com/1433434/47321300-afcf5e80-d654-11e8-8117-127417ab6591.png)
