### PR TITLE
Documentation: Fixed linked to onionElasticBot  

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ __NOTE__: If your deployment directory isn't `/usr/local/lib/ahmia-site` replace
 # FAQ
 
 ## How can populate my index to do searches ?
-You should use [OnionElasticBot](https://github.com/ahmia/ahmia-crawler/tree/master/onionElasticBot) to populate your index.
+You should use [OnionElasticBot](https://github.com/ahmia/ahmia-crawler/tree/master/ahmia) to populate your index.
 
 ## Why can't my browser load django statics ?
 The django settings.py is configured in a way that it only serve statics if DEBUG is True.


### PR DESCRIPTION
Previous link <https://github.com/ahmia/ahmia-crawler/tree/master/onionElasticBot> resulted in a 404.
This might have been a result of renaming `ahmia-crawler/onionElasticBot` to `ahmia-crawler/ahmia` in the past.
The [README.md](https://github.com/ahmia/ahmia-crawler/tree/master/ahmia) in `ahmia-crawler/ahmia`  still mentions `onionElasticBot` which I believe is the right link in this context. 